### PR TITLE
fix: Reference to scripts folder in manisfest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
   "content_scripts": [
     {
       "matches": ["https://meet.google.com/*"],
-      "js": ["script/content.js"],
+      "js": ["scripts/content.js"],
       "run_at": "document_idle"
     }
   ]


### PR DESCRIPTION
Fix bad reference to scripts folder in `manifest.json` file.